### PR TITLE
Basic test case: centos-stream in targets

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -15,19 +15,13 @@ jobs:
     targets:
     - fedora-stable-x86_64
     - fedora-rawhide-x86_64
+    - centos-stream-x86_64
 
 - job: copr_build
   trigger: release
   metadata:
     targets:
     - fedora-stable
-
-- job: tests
-  trigger: pull_request
-  metadata:
-    targets:
-    - fedora-stable-x86_64
-    - fedora-rawhide-x86_64
 
 - job: propose_downstream
   trigger: release

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -13,8 +13,6 @@ jobs:
   trigger: pull_request
   metadata:
     targets:
-    - fedora-stable-x86_64
-    - fedora-rawhide-x86_64
     - centos-stream-x86_64
 
 - job: copr_build


### PR DESCRIPTION
This test case is triggered automatically by our validation script.

```yaml
- job: copr_build
  trigger: pull_request
  metadata:
    targets:
    - centos-stream-x86_64
```