### PR TITLE
Basic test case: copr build only

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -13,21 +13,13 @@ jobs:
   trigger: pull_request
   metadata:
     targets:
-    - fedora-stable-x86_64
-    - fedora-rawhide-x86_64
+    - fedora-all
 
 - job: copr_build
   trigger: release
   metadata:
     targets:
     - fedora-stable
-
-- job: tests
-  trigger: pull_request
-  metadata:
-    targets:
-    - fedora-stable-x86_64
-    - fedora-rawhide-x86_64
 
 - job: propose_downstream
   trigger: release


### PR DESCRIPTION
This test case is triggered automatically by our validation script.

```yaml
- job: copr_build
  trigger: pull_request
  metadata:
    targets:
    - fedora-all
```