### PR TITLE
testing-farm: migrate to official TMT format

### DIFF
--- a/ci.fmf
+++ b/ci.fmf
@@ -1,9 +1,0 @@
----
-/test/build/smoke:
-  execute:
-    how: shell
-    commands:
-      - dnf -y install httpd curl
-      - systemctl start httpd
-      - echo foo > /var/www/html/index.html
-      - curl http://localhost/ | grep foo

--- a/plans/test.fmf
+++ b/plans/test.fmf
@@ -1,0 +1,13 @@
+---
+prepare:
+  how: install
+  package:
+    - curl
+    - httpd
+
+execute:
+  how: tmt
+  script:
+    - systemctl start httpd
+    - echo foo > /var/www/html/index.html
+    - curl http://localhost/ | grep foo


### PR DESCRIPTION
Not sure whenre did `commands` go away, but I believe
this was an `cruncher` archaism.

Move to plans subdir also, no need to name the test now
`ci.fmf`.

And as a last step, use our install prepare step to install
the test requirements.

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>