### PR TITLE
Basic test case: centos-stream in targets

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -13,8 +13,7 @@ jobs:
   trigger: pull_request
   metadata:
     targets:
-    - fedora-stable-x86_64
-    - fedora-rawhide-x86_64
+    - centos-stream-8-x86_64
 
 - job: copr_build
   trigger: release
@@ -28,13 +27,6 @@ jobs:
     branch: main
     targets:
       - fedora-stable
-
-- job: tests
-  trigger: pull_request
-  metadata:
-    targets:
-    - fedora-stable-x86_64
-    - fedora-rawhide-x86_64
 
 - job: propose_downstream
   trigger: release

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,4 +1,5 @@
 ---
+packit_instances: ["prod", "stg"]
 specfile_path: hello.spec
 synced_files:
   - hello.spec
@@ -30,5 +31,6 @@ jobs:
 
 - job: propose_downstream
   trigger: release
+  packit_instances: ["stg"]
   metadata:
     dist-git-branch: fedora-all


### PR DESCRIPTION
This test case is triggered automatically by our validation script.
```yaml
- job: copr_build
  trigger: pull_request
  metadata:
    targets:
    - centos-stream-x86_64
```